### PR TITLE
Using cross-spawn to fix PATHEXT on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var through = require('through2'),
     semver = require('semver'),
     Table = require('cli-table'),
     assign = require('object-assign'),
-    spawn = require('child_process').spawn,
+    spawn = require('cross-spawn'),
     path = require('path');
 
 require('colors');

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",
+    "cross-spawn": "^2.1.4",
     "gulp-util": "^3.0.6",
     "object-assign": "^4.0.1",
     "semver": "^5.0.1",


### PR DESCRIPTION
Spawning on windows fails due to [this issue](https://github.com/nodejs/node-v0.x-archive/issues/2318)
Using cross-spawn as a drop in replacement solves #2 
